### PR TITLE
OF-2283: Show distinct servers when looking at remote S2S details on admin console

### DIFF
--- a/i18n/src/main/resources/openfire_i18n.properties
+++ b/i18n/src/main/resources/openfire_i18n.properties
@@ -2114,8 +2114,10 @@ server.session.summary.sessions_per_page=Sessions per page
 
 # Server Session details Page
 
+server.session.details.domain.title=Remote XMPP domain
 server.session.details.title=Remote Server Connections Details
-server.session.details.info=Below are details about the sessions with the remote server {0}.
+server.session.details.info=Below are details about the sessions with the remote domain {0}.
+server.session.details.domainname=Remote XMPP domain name:
 server.session.details.hostname=Remote server IP / Hostname:
 server.session.details.incoming_session=Incoming Session Details
 server.session.details.streamid=Stream ID

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSession.java
@@ -28,6 +28,7 @@ import java.net.UnknownHostException;
 import java.security.cert.Certificate;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Base class for sessions being hosted in other cluster nodes. Almost all
@@ -121,6 +122,11 @@ public abstract class RemoteSession implements Session {
     public Certificate[] getPeerCertificates() {
         ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.getPeerCertificates);
         return (Certificate[]) doSynchronousClusterTask(task);
+    }
+
+    public Map<String,String> getSoftwareVersion() {
+        ClusterTask<Object> task = getRemoteSessionTask(RemoteSessionTask.Operation.getSoftwareVersion);
+        return (Map<String,String>) doSynchronousClusterTask(task);
     }
 
     public void process(Packet packet) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/session/RemoteSessionTask.java
@@ -78,6 +78,9 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         else if (operation == Operation.getPeerCertificates) {
             result = getSession().getPeerCertificates();
         }
+        else if (operation == Operation.getSoftwareVersion) {
+            result = getSession().getSoftwareVersion();
+        }
         else if (operation == Operation.close) {
             // Run in another thread so we avoid blocking calls (in hazelcast) 
             final Session session = getSession();
@@ -142,6 +145,7 @@ public abstract class RemoteSessionTask implements ClusterTask<Object> {
         getNumServerPackets,
         getCipherSuiteName,
         getPeerCertificates,
+        getSoftwareVersion,
         close,
         isClosed,
         isSecure,

--- a/xmppserver/src/main/webapp/server-session-details.jsp
+++ b/xmppserver/src/main/webapp/server-session-details.jsp
@@ -25,15 +25,12 @@
                  java.text.NumberFormat"
     errorPage="error.jsp"
 %>
-<%@ page import="java.util.Calendar" %>
-<%@ page import="java.util.Date" %>
-<%@ page import="java.util.List" %>
-<%@ page import="java.util.Map" %>
-<%@ page import="java.util.TreeMap" %>
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
 <%@ page import="org.jivesoftware.openfire.cluster.ClusterManager" %>
 <%@ page import="org.jivesoftware.openfire.session.LocalSession" %>
+<%@ page import="java.util.stream.Collectors" %>
+<%@ page import="java.util.*" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
@@ -42,7 +39,7 @@
 <% webManager.init(request, response, session, application, out ); %>
 
 <% // Get parameters
-    String hostname = ParamUtils.getParameter(request, "hostname");
+    String domainname = ParamUtils.getParameter(request, "hostname");
 
     // Handle a "go back" click:
     if (request.getParameter("back") != null) {
@@ -52,13 +49,38 @@
 
     // Get the session & address objects
     SessionManager sessionManager = webManager.getSessionManager();
-    List<IncomingServerSession> inSessions = sessionManager.getIncomingServerSessions(hostname);
-    List<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(hostname);
+    List<IncomingServerSession> inSessions = sessionManager.getIncomingServerSessions(domainname);
+    List<OutgoingServerSession> outSessions = sessionManager.getOutgoingServerSessions(domainname);
 
-    // Number dateFormatter for all numbers on this page:
-    NumberFormat numFormatter = NumberFormat.getNumberInstance();
+    // Sort them by remote peer.
+    final Map<String, Set<IncomingServerSession>> inByHost = inSessions.stream().collect(Collectors.groupingBy(e -> {
+        try {
+            return e.getHostAddress() + " / " + e.getHostName();
+        } catch (Exception t) {
+            return "Invalid session/connection";
+        }
+    }, Collectors.mapping(e -> e, Collectors.toSet())));
+
+    final Map<String, Set<OutgoingServerSession>> outByHost = outSessions.stream().collect(Collectors.groupingBy(e -> {
+        try {
+            return e.getHostAddress() + " / " + e.getHostName();
+        } catch (Exception t) {
+            return "Invalid session/connection";
+        }
+    }, Collectors.mapping(e -> e, Collectors.toSet())));
+
+    final Set<String> allHosts = new HashSet<>();
+    allHosts.addAll(inByHost.keySet());
+    allHosts.addAll(outByHost.keySet());
+
     final boolean clusteringEnabled = ClusterManager.isClusteringStarted() || ClusterManager.isClusteringStarting();
     final Logger Log = LoggerFactory.getLogger("server-session-details.jsp");
+
+    pageContext.setAttribute("domainname", domainname);
+    pageContext.setAttribute("allHosts", allHosts);
+    pageContext.setAttribute("inByHost", inByHost);
+    pageContext.setAttribute("outByHost", outByHost);
+    pageContext.setAttribute("clusteringEnabled", clusteringEnabled);
 %>
 
 <html>
@@ -68,235 +90,254 @@
     </head>
     <body>
 
-<p>
-<fmt:message key="server.session.details.info">
-    <fmt:param value="<b>${fn:escapeXml(hostname)}</b>" />
-</fmt:message>
+        <p>
+            <fmt:message key="server.session.details.info">
+                <fmt:param value="<b>${fn:escapeXml(domainname)}</b>" />
+            </fmt:message>
+        </p>
 
-</p>
-
-<div class="jive-table">
-<table cellpadding="0" cellspacing="0" border="0" width="100%">
-<thead>
-    <tr>
-        <th colspan="2">
-            <fmt:message key="server.session.details.title" />
-        </th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td class="c1">
-            <fmt:message key="server.session.label.connection" />
-        </td>
-        <td>
-        <% if (!inSessions.isEmpty() && outSessions.isEmpty()) { %>
-            <img src="images/incoming_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
-            <fmt:message key="server.session.connection.incoming" />
-        <% } else if (inSessions.isEmpty() && !outSessions.isEmpty()) { %>
-            <img src="images/outgoing_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.outgoing' />" alt="<fmt:message key='server.session.connection.outgoing' />">
-            <fmt:message key="server.session.connection.outgoing" />
-        <% } else { %>
-            <img src="images/both_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.both' />" alt="<fmt:message key='server.session.connection.both' />">
-            <fmt:message key="server.session.connection.both" />
-        <% } %>
-        </td>
-    </tr>
-    <tr>
-        <td class="c1">
-            <fmt:message key="server.session.details.hostname" />
-        </td>
-        <td>
-        <% try {
-            if (!inSessions.isEmpty()) { %>
-                <%= inSessions.get(0).getHostAddress() %>
-                /
-                <%= inSessions.get(0).getHostName() %>
-            <% } else if (!outSessions.isEmpty()) { %>
-                <%= outSessions.get(0).getHostAddress() %>
-                /
-                <%= outSessions.get(0).getHostName() %>
-            <% }
-           } catch (java.net.UnknownHostException e) { %>
-                Invalid session/connection
-        <% } %>
-        </td>
-    </tr>
-</tbody>
-</table>
-
-</div>
-<br>
-    <%  // Show Software Version if there is :
-       try {
-        if (!inSessions.get(0).getSoftwareVersion().isEmpty()) {
-    %>
         <div class="jive-table">
-            <table cellpadding="3" cellspacing="1" border="0" width="100%">
-                <thead>
+            <table cellpadding="0" cellspacing="0" border="0" width="100%">
+                <tr>
+                    <th colspan="2">
+                        <fmt:message key="server.session.details.domain.title" />
+                    </th>
+                </tr>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="server.session.details.domainname" />
+                    </td>
+                    <td>
+                        <c:out value="${domainname}"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="c1">
+                        <fmt:message key="server.session.label.connection" />
+                    </td>
+                    <td>
+                        <c:choose>
+                            <c:when test="${not empty inByHost and empty outByHost}">
+                                <img src="images/incoming_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
+                                <fmt:message key="server.session.connection.incoming" />
+                            </c:when>
+                            <c:when test="${empty inByHost and not empty outByHost}">
+                                <img src="images/outgoing_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.outgoing' />" alt="<fmt:message key='server.session.connection.outgoing' />">
+                                <fmt:message key="server.session.connection.outgoing" />
+                            </c:when>
+                            <c:otherwise>
+                                <img src="images/both_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.both' />" alt="<fmt:message key='server.session.connection.both' />">
+                                <fmt:message key="server.session.connection.both" />
+                            </c:otherwise>
+                        </c:choose>
+                    </td>
+                </tr>
+            </table>
+
+        </div>
+
+        <br/>
+
+        <c:forEach items="${allHosts}" var="host">
+
+            <c:set var="inSessions" value="${inByHost[host]}"/>
+            <c:set var="outSessions" value="${outByHost[host]}"/>
+
+            <div class="jive-table">
+                <table cellpadding="0" cellspacing="0" border="0" width="100%">
                     <tr>
                         <th colspan="2">
-                            <fmt:message key="session.details.software_version"/>
+                            <fmt:message key="server.session.details.title" />
                         </th>
                     </tr>
-                </thead>
-                <tbody>
-                    <% 
-                        Map<String, String> treeMap = new TreeMap<String, String>(inSessions.get(0).getSoftwareVersion());
-                        for (Map.Entry<String, String> entry : treeMap.entrySet()){ %>
+                    <tr>
+                        <td class="c1">
+                            <fmt:message key="server.session.details.hostname" />
+                        </td>
+                        <td>
+                            <c:out value="${host}"/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="c1">
+                            <fmt:message key="server.session.label.connection" />
+                        </td>
+                        <td>
+                            <c:choose>
+                                <c:when test="${not empty inSessions and empty outSessions}">
+                                    <img src="images/incoming_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.incoming' />" alt="<fmt:message key='server.session.connection.incoming' />">
+                                    <fmt:message key="server.session.connection.incoming" />
+                                </c:when>
+                                <c:when test="${empty inSessions and not empty outSessions}">
+                                    <img src="images/outgoing_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.outgoing' />" alt="<fmt:message key='server.session.connection.outgoing' />">
+                                    <fmt:message key="server.session.connection.outgoing" />
+                                </c:when>
+                                <c:otherwise>
+                                    <img src="images/both_32x16.gif" width="32" height="16" border="0" title="<fmt:message key='server.session.connection.both' />" alt="<fmt:message key='server.session.connection.both' />">
+                                    <fmt:message key="server.session.connection.both" />
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                    </tr>
+
+                    <c:choose>
+                        <c:when test="${not empty inSessions and not empty inSessions.toArray()[0].softwareVersion}">
+                            <c:set var="softwareVersion" value="${inSessions.toArray()[0].softwareVersion}"/>
+                        </c:when>
+                        <c:when test="${not empty outSessions and not empty outSessions.toArray()[0].softwareVersion}">
+                            <c:set var="softwareVersion" value="${outSessions.toArray()[0].softwareVersion}"/>
+                        </c:when>
+                        <c:otherwise>
+                            <c:set var="softwareVersion" value=""/>
+                        </c:otherwise>
+                    </c:choose>
+
+                    <!-- Show Software Version if there is any reported. -->
+                    <c:if test="${not empty softwareVersion}">
+                        <c:forEach items="${softwareVersion}" var="entry">
                             <tr>
-                                <td class="c1">
-                                    <%= StringUtils.escapeHTMLTags(entry.getKey().substring(0, 1).toUpperCase()+""+entry.getKey().substring(1)) %>:
+                                <td class="c1" style="text-transform: capitalize">
+                                    <c:out value="${entry.key}"/>
                                 </td>
                                 <td>
-                                    <%= StringUtils.escapeHTMLTags(entry.getValue())%>
+                                    <c:out value="${entry.value}"/>
                                 </td>
                             </tr>
-                        <% 
-                        }
-                    %>
-                </tbody>
-            </table>
-        </div>
-    <%  } 
-    } catch (Exception e) { 
-       Log.error(e.getMessage(), e);%>
-        Invalid session/connection
-    <%} %>
-<br>
+                        </c:forEach>
+                    </c:if>
+                </table>
 
+                <!-- Show details of the incoming sessions for this host -->
+                <c:if test="${not empty inSessions}">
+                    <table cellpadding="3" cellspacing="1" border="0" width="100%">
+                        <tr>
+                            <th width="35%" colspan="2" nowrap><fmt:message key="server.session.details.incoming_session" /> <fmt:message key="server.session.details.streamid" /></th>
+                            <c:if test="${clusteringEnabled}">
+                                <th width="1%" nowrap><fmt:message key="server.session.details.node"/></th>
+                            </c:if>
+                            <th width="10%" nowrap><fmt:message key="server.session.details.authentication"/></th>
+                            <th width="10%" nowrap><fmt:message key="server.session.details.cipher"/></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.label.creation" /></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.label.last_active" /></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.details.incoming_statistics" /></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.details.outgoing_statistics" /></th>
+                        </tr>
 
-<%  // Show details of the incoming sessions'
-    if (!inSessions.isEmpty()) {
-%>
-<b><fmt:message key="server.session.details.incoming_session" /></b>
-<div class="jive-table">
-    <table cellpadding="3" cellspacing="1" border="0" width="100%">
-        <tr>
-            <th width="35%" colspan="2" nowrap><fmt:message key="server.session.details.streamid" /></th>
-            <% if (clusteringEnabled) { %>
-            <th width="1%" nowrap><fmt:message key="server.session.details.node"/></th>
-            <% } %>
-            <th width="10%" nowrap><fmt:message key="server.session.details.authentication"/></th>
-            <th width="10%" nowrap><fmt:message key="server.session.details.cipher"/></th>
-            <th width="1%" nowrap><fmt:message key="server.session.label.creation" /></th>
-            <th width="1%" nowrap><fmt:message key="server.session.label.last_active" /></th>
-            <th width="1%" nowrap><fmt:message key="server.session.details.incoming_statistics" /></th>
-            <th width="1%" nowrap><fmt:message key="server.session.details.outgoing_statistics" /></th>
-        </tr>
-<%
-    for (IncomingServerSession inSession : inSessions) {
-%>
-    <tr>
-        <%  if (inSession.isSecure()) { %>
-            <td width="1%">
-                <img src="images/lock.gif" width="16" height="16" border="0" alt="">
-            </td>
-         <% } else { %>
-            <td width="1%"><img src="images/blank.gif" width="1" height="1" alt=""></td>
-         <% } %>
-        <%
-            Date creationDate = inSession.getCreationDate();
-            Date lastActiveDate = inSession.getLastActiveDate();
+                        <c:forEach items="${inSessions}" var="session">
+                            <tr>
+                                <td width="1%">
+                                    <c:choose>
+                                        <c:when test="${session.secure}">
+                                            <img src="images/lock.gif" width="16" height="16" border="0" alt="A secure connection">
+                                        </c:when>
+                                        <c:otherwise>
+                                            <img src="images/blank.gif" width="1" height="1" alt="Not a secure connection">
+                                        </c:otherwise>
+                                    </c:choose>
+                                </td>
+                                <td><c:out value="${session.streamID}"/></td>
+                                <c:if test="${clusteringEnabled}">
+                                    <td nowrap>
+                                        <c:choose>
+                                            <c:when test="${session['class'].simpleName eq 'LocalIncomingServerSession'}">
+                                                <fmt:message key="server.session.details.local"/>
+                                            </c:when>
+                                            <c:otherwise>
+                                                <fmt:message key="server.session.details.remote"/>
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </td>
+                                </c:if>
+                                <td nowrap>
+                                    <c:choose>
+                                        <c:when test="${session.usingServerDialback}">
+                                            <fmt:message key="server.session.details.dialback"/>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <fmt:message key="server.session.details.tlsauth"/>
+                                        </c:otherwise>
+                                    </c:choose>
+                                <td><c:out value="${session.cipherSuiteName}"/></td>
+                                <td nowrap><fmt:formatDate type="both" value="${session.creationDate}"/></td>
+                                <td nowrap><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
+                                <td align="center" nowrap><fmt:formatNumber type="number" value="${session.numClientPackets}"/></td>
+                                <td align="center" nowrap><fmt:formatNumber type="number" value="${session.numServerPackets}"/></td>
+                            </tr>
+                        </c:forEach>
+                    </table>
+                </c:if>
 
-            Calendar creationCal = Calendar.getInstance();
-            creationCal.setTime(creationDate);
+                <!-- Show details of the outgoing sessions for this host -->
+                <c:if test="${not empty outSessions}">
+                    <table cellpadding="3" cellspacing="1" border="0" width="100%">
+                        <tr>
+                            <th width="35%" colspan="2" nowrap><fmt:message key="server.session.details.outgoing_session" /> <fmt:message key="server.session.details.streamid" /></th>
+                            <c:if test="${clusteringEnabled}">
+                                <th width="1%" nowrap><fmt:message key="server.session.details.node"/></th>
+                            </c:if>
+                            <th width="10%" nowrap><fmt:message key="server.session.details.authentication"/></th>
+                            <th width="10%" nowrap><fmt:message key="server.session.details.cipher"/></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.label.creation" /></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.label.last_active" /></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.details.incoming_statistics" /></th>
+                            <th width="1%" nowrap><fmt:message key="server.session.details.outgoing_statistics" /></th>
+                        </tr>
 
-            Calendar lastActiveCal = Calendar.getInstance();
-            lastActiveCal.setTime(lastActiveDate);
+                        <c:forEach items="${outSessions}" var="session">
+                            <tr>
+                                <td width="1%">
+                                    <c:choose>
+                                        <c:when test="${session.secure}">
+                                            <img src="images/lock.gif" width="16" height="16" border="0" alt="A secure connection">
+                                        </c:when>
+                                        <c:otherwise>
+                                            <img src="images/blank.gif" width="1" height="1" alt="Not a secure connection">
+                                        </c:otherwise>
+                                    </c:choose>
+                                </td>
+                                <td><c:out value="${session.streamID}"/></td>
+                                <c:if test="${clusteringEnabled}">
+                                    <td nowrap>
+                                        <c:choose>
+                                            <c:when test="${session['class'].simpleName eq 'LocalOutgoingServerSession'}">
+                                                <fmt:message key="server.session.details.local"/>
+                                            </c:when>
+                                            <c:otherwise>
+                                                <fmt:message key="server.session.details.remote"/>
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </td>
+                                </c:if>
+                                <td nowrap>
+                                    <c:choose>
+                                    <c:when test="${session.usingServerDialback}">
+                                        <fmt:message key="server.session.details.dialback"/>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <fmt:message key="server.session.details.tlsauth"/>
+                                    </c:otherwise>
+                                    </c:choose>
+                                <td><c:out value="${session.cipherSuiteName}"/></td>
+                                <td nowrap><fmt:formatDate type="both" value="${session.creationDate}"/></td>
+                                <td nowrap><fmt:formatDate type="both" value="${session.lastActiveDate}"/></td>
+                                <td align="center" nowrap><fmt:formatNumber type="number" value="${session.numClientPackets}"/></td>
+                                <td align="center" nowrap><fmt:formatNumber type="number" value="${session.numServerPackets}"/></td>
+                            </tr>
+                        </c:forEach>
+                     </table>
+                </c:if>
 
-            Calendar nowCal = Calendar.getInstance();
+            </div>
 
-            boolean sameCreationDay = nowCal.get(Calendar.DAY_OF_YEAR) == creationCal.get(Calendar.DAY_OF_YEAR) && nowCal.get(Calendar.YEAR) == creationCal.get(Calendar.YEAR);
-            boolean sameActiveDay = nowCal.get(Calendar.DAY_OF_YEAR) == lastActiveCal.get(Calendar.DAY_OF_YEAR) && nowCal.get(Calendar.YEAR) == lastActiveCal.get(Calendar.YEAR);
-        %>
-        <td><%= inSession.getStreamID()%></td>
-        <% if (clusteringEnabled) { %>
-        <td nowrap><% if (inSession instanceof LocalSession) { %><fmt:message key="server.session.details.local"/><% } else { %><fmt:message key="server.session.details.remote"/><% } %></td>
-        <% } %>
-        <td nowrap><% if (inSession.isUsingServerDialback()) { %><fmt:message key="server.session.details.dialback"/><% } else { %><fmt:message key="server.session.details.tlsauth"/><% } %></td>
-        <td><%= inSession.getCipherSuiteName() %></td>
-        <td nowrap><%= sameCreationDay ? JiveGlobals.formatTime(creationDate) : JiveGlobals.formatDateTime(creationDate) %></td>
-        <td nowrap><%= sameActiveDay ? JiveGlobals.formatTime(lastActiveDate) : JiveGlobals.formatDateTime(lastActiveDate) %></td>
-        <td align="center" nowrap><%= numFormatter.format(inSession.getNumClientPackets()) %></td>
-        <td align="center" nowrap><%= numFormatter.format(inSession.getNumServerPackets()) %></td>
-    </tr>
-<%  } %>
-    </table>
-</div>
+            <br/>
 
-<br>
-<%  } %>
+        </c:forEach>
 
-<%  // Show details of the outgoing sessions
-    if (!outSessions.isEmpty()) {
-%>
-<b><fmt:message key="server.session.details.outgoing_session" /></b>
-<div class="jive-table">
-    <table cellpadding="3" cellspacing="1" border="0" width="100%">
-    <tr>
-        <th width="35%" colspan="2" nowrap><fmt:message key="server.session.details.streamid" /></th>
-        <% if (clusteringEnabled) { %>
-        <th width="1%" nowrap><fmt:message key="server.session.details.node"/></th>
-        <% } %>
-        <th width="10%" nowrap><fmt:message key="server.session.details.authentication"/></th>
-        <th width="10%" nowrap><fmt:message key="server.session.details.cipher"/></th>
-        <th width="1%" nowrap><fmt:message key="server.session.label.creation" /></th>
-        <th width="1%" nowrap><fmt:message key="server.session.label.last_active" /></th>
-        <th width="1%" nowrap><fmt:message key="server.session.details.incoming_statistics" /></th>
-        <th width="1%" nowrap><fmt:message key="server.session.details.outgoing_statistics" /></th>
-    </tr>
-<%
-    for (OutgoingServerSession outSession : outSessions) {
-%>
-    <tr>
-        <%  if (outSession.isSecure()) { %>
-        <td width="1%">
-            <img src="images/lock.gif" width="16" height="16" border="0" alt="">
-        </td>
-         <% } else { %>
-        <td width="1%"><img src="images/blank.gif" width="1" height="1" alt=""></td>
-         <% } %>
-        <%
-            Date creationDate = outSession.getCreationDate();
-            Date lastActiveDate = outSession.getLastActiveDate();
-
-            Calendar creationCal = Calendar.getInstance();
-            creationCal.setTime(creationDate);
-
-            Calendar lastActiveCal = Calendar.getInstance();
-            lastActiveCal.setTime(lastActiveDate);
-
-            Calendar nowCal = Calendar.getInstance();
-
-            boolean sameCreationDay = nowCal.get(Calendar.DAY_OF_YEAR) == creationCal.get(Calendar.DAY_OF_YEAR) && nowCal.get(Calendar.YEAR) == creationCal.get(Calendar.YEAR);
-            boolean sameActiveDay = nowCal.get(Calendar.DAY_OF_YEAR) == lastActiveCal.get(Calendar.DAY_OF_YEAR) && nowCal.get(Calendar.YEAR) == lastActiveCal.get(Calendar.YEAR);
-        %>
-        <td><%= outSession.getStreamID()%></td>
-        <% if (clusteringEnabled) { %>
-        <td nowrap><% if (outSession instanceof LocalSession) { %><fmt:message key="server.session.details.local"/><% } else { %><fmt:message key="server.session.details.remote"/><% } %></td>
-        <% } %>
-        <td nowrap><% if (outSession.isUsingServerDialback()) { %><fmt:message key="server.session.details.dialback"/><% } else { %><fmt:message key="server.session.details.tlsauth"/><% } %></td>
-        <td><%= outSession.getCipherSuiteName() %></td>
-        <td nowrap><%= sameCreationDay ? JiveGlobals.formatTime(creationDate) : JiveGlobals.formatDateTime(creationDate) %></td>
-        <td nowrap><%= sameActiveDay ? JiveGlobals.formatTime(lastActiveDate) : JiveGlobals.formatDateTime(lastActiveDate) %></td>
-        <td align="center" nowrap><%= numFormatter.format(outSession.getNumClientPackets()) %></td>
-        <td align="center" nowrap><%= numFormatter.format(outSession.getNumServerPackets()) %></td>
-    </tr>
-<%  } %>
-    </table>
-    </div>
-
-    <br>
-<%  } %>
-
-<br>
-
-<form action="server-session-details.jsp">
-<center>
-<input type="submit" name="back" value="<fmt:message key="session.details.back_button" />">
-</center>
-</form>
+        <form action="server-session-details.jsp">
+            <center>
+                <input type="submit" name="back" value="<fmt:message key="session.details.back_button" />">
+            </center>
+        </form>
 
     </body>
 </html>


### PR DESCRIPTION
The existing implementation assumes that the remote XMPP domain consists of exactly one server. That needs not be the case. The admin console should show server-specific details.